### PR TITLE
Explain de-identified compounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@ This resource was created through the [JUMP-Cell Painting Consortium](https://ju
 
 The MOA annotations were obtained from https://clue.io/repurposing.
 
+Eight of these compounds have been de-identified; they have `broad_sample` values of `Compound1`, `Compound2`, ..., `Compound8`.
+If you are recreating this plate, we recommend replacing them with their counterparts i.e. the other compound in the set with the same MOA:
+
+|moa                         |member_1          |member_2  |
+|:---------------------------|:-----------------|:---------|
+|HMGCR inhibitor             |delta-Tocotrienol |Compound1 |
+|kinesin inhibitor           |ispinesib         |Compound2 |
+|BCL inhibitor               |ABT-737           |Compound3 |
+|PARP inhibitor              |veliparib         |Compound4 |
+|IGF-1 inhibitor             |NVP-AEW541        |Compound5 |
+|tricyclic antidepressant    |dosulepin         |Compound6 |
+|FGFR inhibitor              |BLU9931           |Compound7 |
+|phosphodiesterase inhibitor |quazinone         |Compound8 |
+
+
 ## Files
 
 [`JUMP-MOA_compound_metadata.tsv`](JUMP-MOA_compound_metadata.tsv)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The MOA annotations were obtained from https://clue.io/repurposing.
 Eight of these compounds have been de-identified; they have `broad_sample` values of `Compound1`, `Compound2`, ..., `Compound8`.
 If you are recreating this plate, we recommend replacing them with their counterparts i.e. the other compound in the set with the same MOA:
 
-|moa                         |member_1          |member_2  |
+|moa                         |replace_with      |original  |
 |:---------------------------|:-----------------|:---------|
 |HMGCR inhibitor             |delta-Tocotrienol |Compound1 |
 |kinesin inhibitor           |ispinesib         |Compound2 |


### PR DESCRIPTION
Explain that some compounds have been de-identified and that we recommend replacing them with their counterparts

This is how I got the map:

```r
read_tsv("https://raw.githubusercontent.com/jump-cellpainting/JUMP-MOA/master/JUMP-MOA_compound_metadata.tsv") %>% filter(str_detect(pert_iname, "Compound")) %>% select(moa) %>% inner_join(df) %>% select(pert_iname, moa) %>% mutate(pert_iname = ifelse(str_detect(pert_iname, "Compound"), paste0("x", pert_iname), pert_iname)) %>% arrange(moa, pert_iname) %>% group_by(moa) %>% mutate(i = seq_along(moa)) %>% ungroup() %>% pivot_wider(names_from = i, values_from = pert_iname, names_prefix = "member_") %>% arrange(member_2) %>% mutate(member_2 = str_replace(member_2, "^x", "")) %>% knitr::kable()
```


